### PR TITLE
fixes deleting selection in multi-select boxes using backspace.

### DIFF
--- a/chosen/chosen.mootools.js
+++ b/chosen/chosen.mootools.js
@@ -841,7 +841,7 @@
 				this.choice_destroy(this.pending_backstroke.getElement("a"));
 				return this.clear_backstroke();
 			}else{
-				this.pending_backstroke = this.search_container.getLast("li.search-choice");
+				this.pending_backstroke = this.search_choices.getLast("li.search-choice");
 				return this.pending_backstroke.addClass("search-choice-focus");
 			}
 		};


### PR DESCRIPTION
When pressing backspace, it did not delete the last option. This fixes that.
