### PR TITLE
optimized search when html contains trailing spaces or is un-trimmed.

### DIFF
--- a/Source/chosen.js
+++ b/Source/chosen.js
@@ -617,11 +617,11 @@ var Chosen = new Class({
 					found = false;
 					result_id = option.dom_id
 
-					if (regex.test(option.html)){
+					if (regex.test(option.text)){
 						found = true;
 						results += 1;
-					}else if (option.html.indexOf(" ") >= 0 || option.html.indexOf("[") === 0){
-						parts = option.html.replace(/\[|\]/g, "").split(" ");
+					}else if (option.text.indexOf(" ") >= 0 || option.text.indexOf("[") === 0){
+						parts = option.text.replace(/\[|\]/g, "").split(" ");
 
 						if (parts.length){
 							parts.each(function(part){
@@ -959,9 +959,9 @@ var SelectParser = new Class({
 				this.parsed.push({
 					array_index: this.parsed.length,
 					options_index: this.options_index,
-					value: option.value,
-					text: option.text,
-					html: option.innerHTML,
+					value: option.get("value"),
+					text: option.get("text").trim(),
+					html: option.get("html"),
 					selected: option.selected,
 					disabled: group_disabled === true ? group_disabled : option.disabled,
 					group_array_index: group_position


### PR DESCRIPTION
Consider this select:

``` html
<select>
   <option value="">                              </option>
   <option value="1">                        One               </option>
   <option value="2">                        Two               </option>
   <option value="3">                        Three               </option>
</select>
```

And try to search the letter "T" in the search box, you'll get no results, cause of the spaces in the option elements.
Sometimes is not possible to have correct html 'cause it's the result of a  server-side processing.

So the point is; the chosen library should evaulate the options' text values after trimming them.
